### PR TITLE
WIP: enhance Serial API JSON

### DIFF
--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -123,7 +123,10 @@ void handleSerial()
             releaseJSONBufferLock();
             return;
           }
-          verboseResponse = deserializeState(pDoc->as<JsonObject>());
+          JsonObject root = pDoc->as<JsonObject>();
+          verboseResponse = deserializeState(root);
+          //if JSON contains networking key then initiate saving of config
+          if (root.containsKey("nw")) doSerializeConfig = true;
           //only send response if TX pin is unused for other purposes
           if (verboseResponse && (!pinManager.isPinAllocated(hardwareTX) || pinManager.getPinOwner(hardwareTX) == PinOwner::DebugOut)) {
             pDoc->clear();


### PR DESCRIPTION
The Serial API for JSON currently does not support writing to cfg.json - this is an attempt to add it with code taken from wled_server.cpp - feedback and guidance is needed please because as I non-developer there is something wrong with my implementation that I cannot figure out